### PR TITLE
Only wrap JSXElement contents with a single child

### DIFF
--- a/client/code.js
+++ b/client/code.js
@@ -1,0 +1,45 @@
+ 
+import React from 'react';
+
+const hi = () => 'hi';
+
+const yostrlit = <p>'YO'</p>;
+const yo = <p>YO</p>;
+const foo = <p>{ hi() }</p>;
+
+hi('there');
+
+const one = <p>yo</p>;
+const three = (
+  <p>
+  	yo!
+  	what up?
+  </p>
+ );
+const four = <p>{ 'yo' }</p>;
+const six = <p>{ `what? ${hi()}` }</p>;
+const seven = (
+  <div>
+    <div><i /></div>
+    <p>
+      { 'yo' }
+      'there'
+    </p>
+  </div>
+);
+
+class Some extends React.Component {
+	render() {
+    	return (
+          <div>Hi</div>
+        );
+    }
+}
+
+let languages = {
+  'what up :user!': {
+    'fr': 'salut :user!',
+  }
+};
+
+const greeting = <p>{ `what up ${'t-bizzle'}` }</p>;

--- a/myPlugin.js
+++ b/myPlugin.js
@@ -5,46 +5,33 @@ const template = require('babel-template');
 const includeAst = template(`var translate = require('babel-translate-plugin').translate;`)();
 
 module.exports = function ({ types: t }) {
-  const isWhitespaceBetweenJSXElements = (path) => {
-    // const currentNodeKey = path.key;
-    // // Case 1: Current node is first
-    // // Case 2: Current node is somewhere in the middle
-    // // Case 3: Current node is last
-    // if (currentNodeKey !== 0 && currentNodeKey !== path.container.length) {
-    //   // Check if the adjacent siblings are JSXExpressionContainers
-    //   const aboveSibling = path.getSibling(currentNodeKey - 1);
-    //   const belowSibling = path.getSibling(currentNodeKey + 1);
-    //   if (t.isJSXExpressionContainer(aboveSibling)) {
-    //     console.log('Above sibling is a JSX container');
-    //   }
-    //   if (t.isJSXExpressionContainer(belowSibling)) {
-    //     console.log('Below sibling is a JSX container');
-    //   }
-    // }
-    // TODO Find a better way to check the types for this - look at Babel Types
-    // A value that has at least one non whitespace character will match this
-    // regex
-    return !/\S+/.test(path.node.value);
-    // return node.value === '\n       ';
-  };
-
   const wrapWithTranslateFn = (args) => {
     return t.callExpression(t.identifier('translate'), args);
   };
 
-  // TODO ignore whitespace between:
-  // - ADJ JSX elements
-  // - ADJ JSXExpressions
+  const JSXChildrenVisitor = {
+    JSXExpressionContainer: {
+      exit(path, state) {
+        state.changed = true;
+        path.node.expression = wrapWithTranslateFn([path.node.expression]);
+      },
+    },
 
-  // Idea: Only translate code INSIDE Class Declarations - nested visitors
-  // TODO: use `path.get('callee') instead of path.callee`
-  // https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#get-the-path-of-sub-node
+    JSXText(path, state) {
+      const { value } = path.node;
+      if (value.trim() === "") {
+        return;
+      }
 
-  // Find the specific parent path
-  // https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#find-a-specific-parent-path
-
-  // TODO Throw babel translation errors
-  // throw path.buildCodeFrameError("Error message here");
+      state.changed = true;
+      // JSXText needs to be extracted and transformed into a
+      // StringLiteral to be passed as an argument
+      path.replaceWith(t.JSXExpressionContainer(
+        wrapWithTranslateFn([t.stringLiteral(value)])
+      ));
+      path.skip();
+    },
+  }
 
   return {
     // Require the JSX syntax
@@ -65,62 +52,26 @@ module.exports = function ({ types: t }) {
 
       /**
        * The JSXElement visitor transforms the contents of a JSX element if it
-       * has a single child which is not another JSX element.
+       * has a  child which is not another JSX element.
        *
        * This ensures that all of the content rendered by react is wrapped in a
        * translate function; nothing else will be wrapped.
        */
       JSXElement(path, state) {
         const { children } = path.node;
-        if (children.length !== 1) {
+        if (children.length === 0) {
           return;
         }
 
-        const child = children[0];
-        if (t.isJSXElement(child)) {
-          return;
-        }
-
-        // modify the local state which is used in the Program visitor to add a
-        // translate require on exit.
-        state.changed = true;
-
-        // This is already wrapped in an expression container (ie <p>{...}</p>)
-        // therefore we only replace the expression container's children
-        if (t.isJSXExpressionContainer(child)) {
-          child.expression = wrapWithTranslateFn([child.expression]);
-          return;
-        }
-
-        // From here we need to wrap everything with both an expression
-        // container ({..}) for our function call _and_ the translate fn.
-
-        // TODO: Any string values will have escaped whitespace inside them.
-        // Please fix.
-
-        switch(child.type) {
-          case 'JSXText':
-            // JSXText needs to be extracted and transformed into a
-            // StringLiteral to be passed as an argument
-            path.node.children = [t.JSXExpressionContainer(
-              wrapWithTranslateFn([t.stringLiteral(child.value)])
-            )];
-            break;
-          default:
-            // By default use the JSXElement's child as the argument to
-            // translate.  The translate function will be a no-op if this
-            // is not a string.
-            // TODO: This could potentially be smarter (numeric types etc.)
-            path.node.children = [t.JSXExpressionContainer(
-              wrapWithTranslateFn([child.value])
-            )];
-        }
+        path.traverse(JSXChildrenVisitor, state);
+        path.skip();
       },
 
       ImportDeclaration(path) {
         // Skip all import declarations and their children
         path.skip();
       },
+
       JSXAttribute(path) {
         // Skip any JSX attributes
         path.skip();

--- a/myPlugin.js
+++ b/myPlugin.js
@@ -1,5 +1,10 @@
-module.exports = function (babel) {
-  const { types: t } = babel;
+const template = require('babel-template');
+
+// includeAst is an AST representing the require call for adding our
+// translation function to each source file we modify.
+const includeAst = template(`var translate = require('babel-translate-plugin').translate;`)();
+
+module.exports = function ({ types: t }) {
   const isWhitespaceBetweenJSXElements = (path) => {
     // const currentNodeKey = path.key;
     // // Case 1: Current node is first
@@ -40,10 +45,78 @@ module.exports = function (babel) {
 
   // TODO Throw babel translation errors
   // throw path.buildCodeFrameError("Error message here");
+
   return {
     // Require the JSX syntax
     inherits: require("babel-plugin-syntax-jsx"),
     visitor: {
+      Program: {
+        enter(path, state) {
+          // upon entering each source file reset the state so that we don't
+          // add translate requires when unnecessary
+          state.changed = false;
+        },
+        exit(path, state) {
+          if (state.changed) {
+            path.unshiftContainer('body', includeAst);
+          }
+        },
+      },
+
+      /**
+       * The JSXElement visitor transforms the contents of a JSX element if it
+       * has a single child which is not another JSX element.
+       *
+       * This ensures that all of the content rendered by react is wrapped in a
+       * translate function; nothing else will be wrapped.
+       */
+      JSXElement(path, state) {
+        const { children } = path.node;
+        if (children.length !== 1) {
+          return;
+        }
+
+        const child = children[0];
+        if (t.isJSXElement(child)) {
+          return;
+        }
+
+        // modify the local state which is used in the Program visitor to add a
+        // translate require on exit.
+        state.changed = true;
+
+        // This is already wrapped in an expression container (ie <p>{...}</p>)
+        // therefore we only replace the expression container's children
+        if (t.isJSXExpressionContainer(child)) {
+          child.expression = wrapWithTranslateFn([child.expression]);
+          return;
+        }
+
+        // From here we need to wrap everything with both an expression
+        // container ({..}) for our function call _and_ the translate fn.
+
+        // TODO: Any string values will have escaped whitespace inside them.
+        // Please fix.
+
+        switch(child.type) {
+          case 'JSXText':
+            // JSXText needs to be extracted and transformed into a
+            // StringLiteral to be passed as an argument
+            path.node.children = [t.JSXExpressionContainer(
+              wrapWithTranslateFn([t.stringLiteral(child.value)])
+            )];
+            break;
+          default:
+            // By default use the JSXElement's child as the argument to
+            // translate.  The translate function will be a no-op if this
+            // is not a string.
+            // TODO: This could potentially be smarter (numeric types etc.)
+            path.node.children = [t.JSXExpressionContainer(
+              wrapWithTranslateFn([child.value])
+            )];
+        }
+      },
+
       ImportDeclaration(path) {
         // Skip all import declarations and their children
         path.skip();
@@ -52,38 +125,6 @@ module.exports = function (babel) {
         // Skip any JSX attributes
         path.skip();
       },
-      StringLiteral(path) {
-        // If the parent of the string literal is the translate function,
-        // ignore it because we added the string literal in the JSX text visitor
-        const parent = path.parentPath.node;
-        if (t.isCallExpression(parent) && parent.callee.name === 'translate') {
-          console.log('Skipping ', path.node.value);
-          path.skip();
-        } else if (path.listKey === 'arguments') {
-          // Skip string literal arguments to functions
-          console.log('Skipping for LIST KEY ', path.node.value);
-          path.skip();
-        } else {
-          path.replaceWith(
-            wrapWithTranslateFn([t.stringLiteral(path.node.value)])
-          );
-        }
-      },
-      JSXText(path) {
-        if (!isWhitespaceBetweenJSXElements(path)) {
-          // If the parent is a JSXElement, wrap in a JSX Expression container
-          // console.log('JSXText', path.node.value);
-          path.replaceWith(
-            // Call the function 'translate' with arguments of [path.node.value]
-            // Do not parse the same node twice!
-            // TODO Add language as second arg
-            t.JSXExpressionContainer(
-              wrapWithTranslateFn([t.stringLiteral(path.node.value)])
-            )
-
-          );
-        }
-      }
     },
   };
 };


### PR DESCRIPTION
This ensures that all text rendered to the DOM will be translated _if_
it's a single child.

Translated:

	<p>hi</p>
	<p>{ "hi" }</p>
	<p>{ hi() }</p>
	<p>{ `what? ${hi()}` }</p>

Not translated:

	<p>{ "yo" } there</p> (use template literals)